### PR TITLE
Only update `target_pwm` if fan speed has changed

### DIFF
--- a/fanctl.py
+++ b/fanctl.py
@@ -31,19 +31,19 @@ if MAX_PERF > 0:
         print(f"Error calling jetson_clocks: {repr(e)}")
 
 
-def read_temp():
+def read_temp() -> int:
     with open("/sys/devices/virtual/thermal/thermal_zone0/temp", "r") as file:
         temp_raw = file.read()
     temp = int(temp_raw) / 1000
     return temp
 
 
-def fan_curve(temp):
+def fan_curve(temp: int) -> int:
     spd = 255 * (temp - FAN_OFF_TEMP) / (FAN_MAX_TEMP - FAN_OFF_TEMP)
     return int(min(max(0, spd), 255))
 
 
-def set_speed(spd):
+def set_speed(spd: int) -> None:
     with open("/sys/devices/pwm-fan/target_pwm", "w") as file:
         file.write(f"{spd}")
 

--- a/fanctl.py
+++ b/fanctl.py
@@ -49,8 +49,12 @@ def set_speed(spd):
 
 
 print("Setup complete.\nRunning normally.")
+
+last_spd = 0
 while True:
     temp = read_temp()
     spd = fan_curve(temp)
-    set_speed(spd)
+    if spd != last_spd:
+        set_speed(spd)
+        last_spd = spd
     time.sleep(UPDATE_INTERVAL)

--- a/fanctl.py
+++ b/fanctl.py
@@ -52,5 +52,5 @@ print("Setup complete.\nRunning normally.")
 while True:
     temp = read_temp()
     spd = fan_curve(temp)
-    out = set_speed(spd)
+    set_speed(spd)
     time.sleep(UPDATE_INTERVAL)

--- a/fanctl.py
+++ b/fanctl.py
@@ -10,7 +10,7 @@ try:
     FAN_MAX_TEMP = config["FAN_MAX_TEMP"]
     UPDATE_INTERVAL = config["UPDATE_INTERVAL"]
     MAX_PERF = config["MAX_PERF"]
-except:
+except Exception:
     print(
         (
             "error loading /etc/automagic-fan/config.json.\n"

--- a/fanctl.py
+++ b/fanctl.py
@@ -1,50 +1,56 @@
 #!/usr/bin/python3
-
 import time
 import json
 import subprocess as sp
 
 try:
-	with open("/etc/automagic-fan/config.json","r") as file:
-		config=json.load(file)
-	FAN_OFF_TEMP=config["FAN_OFF_TEMP"]
-	FAN_MAX_TEMP=config["FAN_MAX_TEMP"]
-	UPDATE_INTERVAL=config["UPDATE_INTERVAL"]
-	MAX_PERF=config["MAX_PERF"]
+    with open("/etc/automagic-fan/config.json", "r") as file:
+        config = json.load(file)
+    FAN_OFF_TEMP = config["FAN_OFF_TEMP"]
+    FAN_MAX_TEMP = config["FAN_MAX_TEMP"]
+    UPDATE_INTERVAL = config["UPDATE_INTERVAL"]
+    MAX_PERF = config["MAX_PERF"]
 except:
-	print("error loading /etc/automagic-fan/config.json.\nPlease check your config file.\nProceeding with default settings.")
-	FAN_OFF_TEMP=20
-	FAN_MAX_TEMP=50
-	UPDATE_INTERVAL=2
-	MAX_PERF=0
+    print(
+        (
+            "error loading /etc/automagic-fan/config.json.\n"
+            "Please check your config file.\n"
+            "Proceeding with default settings."
+        )
+    )
+    FAN_OFF_TEMP = 20
+    FAN_MAX_TEMP = 50
+    UPDATE_INTERVAL = 2
+    MAX_PERF = 0
 
-if MAX_PERF>0:
-	print("Maximizing clock speeds with jetson_clocks")
-	try:
-		sp.call("jetson_clocks")
-	except Exception as e:
-		print(f"Error calling jetson_clocks: {repr(e)}")
+if MAX_PERF > 0:
+    print("Maximizing clock speeds with jetson_clocks")
+    try:
+        sp.call("jetson_clocks")
+    except Exception as e:
+        print(f"Error calling jetson_clocks: {repr(e)}")
 
 
 def read_temp():
-	with open("/sys/devices/virtual/thermal/thermal_zone0/temp","r") as file:
-		temp_raw=file.read()
-	temp=int(temp_raw)/1000
-	return temp
+    with open("/sys/devices/virtual/thermal/thermal_zone0/temp", "r") as file:
+        temp_raw = file.read()
+    temp = int(temp_raw) / 1000
+    return temp
+
 
 def fan_curve(temp):
-	spd=255*(temp-FAN_OFF_TEMP)/(FAN_MAX_TEMP-FAN_OFF_TEMP)
-	return int(min(max(0,spd),255))
+    spd = 255 * (temp - FAN_OFF_TEMP) / (FAN_MAX_TEMP - FAN_OFF_TEMP)
+    return int(min(max(0, spd), 255))
+
 
 def set_speed(spd):
-	with open("/sys/devices/pwm-fan/target_pwm","w") as file:
-		file.write(f"{spd}")
+    with open("/sys/devices/pwm-fan/target_pwm", "w") as file:
+        file.write(f"{spd}")
+
 
 print("Setup complete.\nRunning normally.")
 while True:
-	temp=read_temp()
-	spd=fan_curve(temp)
-	out=set_speed(spd)
-	time.sleep(UPDATE_INTERVAL)
-
-
+    temp = read_temp()
+    spd = fan_curve(temp)
+    out = set_speed(spd)
+    time.sleep(UPDATE_INTERVAL)


### PR DESCRIPTION
Marc, first of all thank you for your Jetson fan speed controller!

This PR's main intent is to make it so that `target_pwm` is only written when the fan speed changes instead of every `UPDATE_INTERVAL` seconds.

I also updated the formatting, added type hints and made the code PEP8 friendly.
I put each change into a separate commit so it would be easier to review.
